### PR TITLE
Use only spaces in code example

### DIFF
--- a/pre-requisites/credential-souce-repository.md
+++ b/pre-requisites/credential-souce-repository.md
@@ -33,61 +33,61 @@ use Webauthn\PublicKeyCredentialUserEntity;
 
 class PublicKeyCredentialSourceRepository implements PublicKeyCredentialSourceRepositoryInterface
 {
-	private $path = '/tmp/pubkey-repo.json';
+    private $path = '/tmp/pubkey-repo.json';
 
     public function findOneByCredentialId(string $publicKeyCredentialId): ?PublicKeyCredentialSource
-	{
-		$data = $this->read();
+    {
+        $data = $this->read();
         if (isset($data[base64_encode($publicKeyCredentialId)]))
         {
             return PublicKeyCredentialSource::createFromArray($data[base64_encode($publicKeyCredentialId)]);
-		}
-		return null;
-	}
+        }
+        return null;
+    }
 
     /**
      * @return PublicKeyCredentialSource[]
      */
     public function findAllForUserEntity(PublicKeyCredentialUserEntity $publicKeyCredentialUserEntity): array
-	{
-		$sources = [];
-		foreach($this->read() as $data)
-		{
-			$source = PublicKeyCredentialSource::createFromArray($data);
-			if ($source->getUserHandle() === $publicKeyCredentialUserEntity->getId())
-			{
-				$sources[] = $source;
-			}
-		}
-		return $sources;
-	}
+    {
+        $sources = [];
+        foreach($this->read() as $data)
+        {
+            $source = PublicKeyCredentialSource::createFromArray($data);
+            if ($source->getUserHandle() === $publicKeyCredentialUserEntity->getId())
+            {
+                $sources[] = $source;
+            }
+        }
+        return $sources;
+    }
 
     public function saveCredentialSource(PublicKeyCredentialSource $publicKeyCredentialSource): void
-	{
-		$data = $this->read();
-		$data[base64_encode($publicKeyCredentialSource->getPublicKeyCredentialId())] = $publicKeyCredentialSource;
-		$this->write($data);
-	}
+    {
+        $data = $this->read();
+        $data[base64_encode($publicKeyCredentialSource->getPublicKeyCredentialId())] = $publicKeyCredentialSource;
+        $this->write($data);
+    }
 
-	private function read(): array
-	{
-		if (file_exists($this->path))
-		{
-			return json_decode(file_get_contents($this->path), true);
-		}
-		return [];
-	}
+    private function read(): array
+    {
+        if (file_exists($this->path))
+        {
+            return json_decode(file_get_contents($this->path), true);
+        }
+        return [];
+    }
 
-	private function write(array $data): void
-	{
-		if (!file_exists($this->path))
-		{
+    private function write(array $data): void
+    {
+        if (!file_exists($this->path))
+        {
             if (!mkdir($concurrentDirectory = dirname($this->path), 0700, true) && !is_dir($concurrentDirectory)) {
                 throw new \RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
             }
-		}
-		file_put_contents($this->path, json_encode($data), LOCK_EX);
-	}
+        }
+        file_put_contents($this->path, json_encode($data), LOCK_EX);
+    }
 }
 ```
 {% endcode %}


### PR DESCRIPTION
The indentation in the code example was a mixture of tabs and spaces which makes it hard to read on the website: https://webauthn-doc.spomky-labs.com/pre-requisites/credential-souce-repository#filesystem-repository