### PR TITLE
Replace UuidInterface by AbstractUid and use Doctrine\ORM\Mapping as ORM

### DIFF
--- a/the-webauthn-server/the-symfony-way/entities-with-doctrine.md
+++ b/the-webauthn-server/the-symfony-way/entities-with-doctrine.md
@@ -22,36 +22,37 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
-use App\Repository\PublicKeyCredentialSourceRepository;
-use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\Column;
-use Doctrine\ORM\Mapping\GeneratedValue;
-use Doctrine\ORM\Mapping\Id;
-use Doctrine\ORM\Mapping\Table;
 use Symfony\Component\Uid\Ulid;
-use Webauthn\PublicKeyCredentialSource as BasePublicKeyCredentialSource;
+use Doctrine\ORM\Mapping as ORM;
 use Webauthn\TrustPath\TrustPath;
+use Symfony\Component\Uid\AbstractUid;
+use App\Repository\PublicKeyCredentialSourceRepository;
+use Webauthn\PublicKeyCredentialSource as BasePublicKeyCredentialSource;
 
-#[Table(name: "public_key_credential_sources")]
-#[Entity(repositoryClass: PublicKeyCredentialSourceRepository::class)]
-class PublicKeyCredentialSource extends BasePublicKeyCredentialSource
-{
-    #[Id]
-    #[Column(type: "ulid", unique: true)]
-    #[GeneratedValue(strategy: "NONE")]
+#[ORM\Entity(repositoryClass: PublicKeyCredentialSourceRepository::class)]
+class PublicKeyCredentialSource extends BasePublicKeyCredentialSource {
+    #[ORM\Id]
+    #[ORM\Column(type: "ulid", unique: true)]
+    #[ORM\GeneratedValue(strategy: "NONE")]
     private string $id;
 
-    public function __construct(string $publicKeyCredentialId, string $type, array $transports, string $attestationType, TrustPath $trustPath, UuidInterface $aaguid, string $credentialPublicKey, string $userHandle, int $counter)
-    {
+    public function __construct(string $publicKeyCredentialId, string $type, array $transports, string $attestationType, TrustPath $trustPath, AbstractUid $aaguid, string $credentialPublicKey, string $userHandle, int $counter
+    ) {
         $this->id = Ulid::generate();
         parent::__construct($publicKeyCredentialId, $type, $transports, $attestationType, $trustPath, $aaguid, $credentialPublicKey, $userHandle, $counter);
     }
 
-    public function getId(): string
-    {
+    public function getId(): ?string {
         return $this->id;
     }
+
+    public function setId(?string $id): self {
+        $this->id = $id;
+
+        return $this;
+    }
 }
+
 ```
 {% endcode %}
 

--- a/the-webauthn-server/the-symfony-way/entities-with-doctrine.md
+++ b/the-webauthn-server/the-symfony-way/entities-with-doctrine.md
@@ -80,7 +80,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\PublicKeyCredentialSource;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepository as BasePublicKeyCredentialSourceRepository;
 use Webauthn\PublicKeyCredentialSource as BasePublicKeyCredentialSource;
 

--- a/the-webauthn-server/the-symfony-way/entities-with-doctrine.md
+++ b/the-webauthn-server/the-symfony-way/entities-with-doctrine.md
@@ -31,6 +31,7 @@ use Doctrine\ORM\Mapping\Table;
 use Symfony\Component\Uid\Ulid;
 use Webauthn\PublicKeyCredentialSource as BasePublicKeyCredentialSource;
 use Webauthn\TrustPath\TrustPath;
+use Symfony\Component\Uid\AbstractUid;
 
 #[Table(name: "public_key_credential_sources")]
 #[Entity(repositoryClass: PublicKeyCredentialSourceRepository::class)]
@@ -41,7 +42,7 @@ class PublicKeyCredentialSource extends BasePublicKeyCredentialSource
     #[GeneratedValue(strategy: "NONE")]
     private string $id;
 
-    public function __construct(string $publicKeyCredentialId, string $type, array $transports, string $attestationType, TrustPath $trustPath, UuidInterface $aaguid, string $credentialPublicKey, string $userHandle, int $counter)
+    public function __construct(string $publicKeyCredentialId, string $type, array $transports, string $attestationType, TrustPath $trustPath, AbstractUid $aaguid, string $credentialPublicKey, string $userHandle, int $counter)
     {
         $this->id = Ulid::generate();
         parent::__construct($publicKeyCredentialId, $type, $transports, $attestationType, $trustPath, $aaguid, $credentialPublicKey, $userHandle, $counter);


### PR DESCRIPTION
Replace `UuidInterface` by `AbstractUid` from `Symfony\Component\Uid` on the `__construct function` of the `PublicKeyCredentialSource` class.