### PR TITLE
Document mandatory UV flag check and corrected override defaults

### DIFF
--- a/symfony-bundle/advanced-behaviors/client-override-policy.md
+++ b/symfony-bundle/advanced-behaviors/client-override-policy.md
@@ -16,6 +16,8 @@ Each policy field has:
 
 ## Configuration
 
+The example below shows every field with an explicit value. You only need to declare the fields you want to change — the rest fall back to the [defaults](#configurable-fields) listed in the next section.
+
 {% code title="config/packages/webauthn.yaml" lineNumbers="true" %}
 ```yaml
 webauthn:
@@ -26,7 +28,7 @@ webauthn:
             client_override_policy:
                 user_verification:
                     enabled: true
-                    allowed_values: ['required', 'preferred', 'discouraged']
+                    allowed_values: ['required', 'preferred']
                 authenticator_attachment:
                     enabled: true
                     allowed_values: ['platform', 'cross-platform']
@@ -46,14 +48,18 @@ webauthn:
 
 ## Configurable Fields
 
-| Field | Default | Allowed Values | Description |
-|-------|---------|----------------|-------------|
-| `user_verification` | enabled | `required`, `preferred`, `discouraged` | Whether the client can request a specific user verification level |
+| Field | Default | Default Allowed Values | Description |
+|-------|---------|------------------------|-------------|
+| `user_verification` | **disabled** | `required`, `preferred` | Whether the client can request a specific user verification level. Disabled by default to prevent downgrade attacks; `discouraged` is excluded from the defaults even when you enable the override. |
 | `authenticator_attachment` | enabled | `platform`, `cross-platform` | Whether the client can request a specific authenticator type |
 | `resident_key` | enabled | `required`, `preferred`, `discouraged` | Whether the client can request resident key behavior |
 | `attestation_conveyance` | enabled | `none`, `indirect`, `direct`, `enterprise` | Whether the client can request attestation preference |
 | `extensions` | enabled | N/A | Whether the client can provide additional extensions |
 | `mediation` | **disabled** | `default`, `conditional` | Whether the client can request the [Conditional Create](../../pure-php/advanced-behaviours/conditional-create.md) flow (auto-register) — opt-in. |
+
+{% hint style="warning" %}
+**Why `user_verification` is disabled by default.** Allowing a client to override the user verification requirement makes it possible to request `discouraged` against a profile that mandates `required`, which silently weakens the security guarantee. If you enable this override, keep `discouraged` out of `allowed_values` and **always re-check the `UV` flag at the application layer** — see [User Verification](../../webauthn-in-a-nutshell/user-verification.md#checking-the-uv-flag).
+{% endhint %}
 
 ## Examples
 

--- a/webauthn-in-a-nutshell/user-verification.md
+++ b/webauthn-in-a-nutshell/user-verification.md
@@ -103,25 +103,38 @@ $authenticatorSelection = AuthenticatorSelectionCriteria::create(
 
 ## Checking the UV Flag
 
-After authentication or registration, verify whether user verification actually occurred:
+The `userVerification` setting in the credential options is a **request** sent to the authenticator, not a guarantee. The `CheckUserVerification` ceremony step enforces it against the options that were actually emitted to the client — so if those options were built with a weaker requirement than your profile (for example, because [Client Override Policy](../symfony-bundle/advanced-behaviors/client-override-policy.md) is configured to allow a client to lower it), the ceremony will pass even though no verification took place.
+
+{% hint style="warning" %}
+**Mandatory for sensitive operations.** Do not rely solely on `userVerification: required` in the profile to gate access to privileged actions (admin, payment, secret rotation, AAL2/AAL3 compliance). Always re-check the `UV` flag on the returned authenticator data after a successful ceremony. This is your final, authoritative signal that user verification actually occurred.
+{% endhint %}
+
+After authentication or registration, inspect the flag on the response's authenticator data and decide whether to proceed:
 
 {% code lineNumbers="true" %}
 ```php
-// During assertion validation
-$authenticatorData = $publicKeyCredential->response->getAuthenticatorData();
+// $authenticatorResponse is the AuthenticatorAssertionResponse or
+// AuthenticatorAttestationResponse that was just successfully validated.
+$authenticatorData = $authenticatorResponse instanceof AuthenticatorAssertionResponse
+    ? $authenticatorResponse->authenticatorData
+    : $authenticatorResponse->attestationObject->authData;
 
-// Check if user was verified
-$userVerified = $authenticatorData->isUserVerified();
-
-if ($userVerified) {
-    echo "User identity verified via PIN, biometric, or password";
-} else {
-    echo "Only user presence confirmed (button press/touch)";
+if (! $authenticatorData->isUserVerified()) {
+    // Only user presence was confirmed (button press / touch).
+    // Reject for sensitive flows even if the ceremony succeeded.
+    throw new AccessDeniedHttpException('User verification is required for this action.');
 }
 
-// You can also check the flags directly
+// Safe to proceed with the privileged operation
+```
+{% endcode %}
+
+You can also read the raw flags if you need fine-grained checks (for example combining `UV` with `BS`/`BE` for backup-eligibility policies):
+
+{% code lineNumbers="true" %}
+```php
 $flags = $authenticatorData->getFlags();
-$uvFlag = ($flags & 0x04) !== 0;  // UV flag is bit 2
+$uvFlag = (ord($flags) & 0x04) !== 0;  // UV flag is bit 2
 ```
 {% endcode %}
 


### PR DESCRIPTION
Port of #41 to the 5.4 documentation branch.

## Summary

- Make it explicit that the `userVerification` option is a **request**, not a guarantee, and that applications gating sensitive operations must re-check the `UV` flag on the returned authenticator data after a successful ceremony.
- Update the [Client Override Policy](https://webauthn-doc.spomky-labs.com/symfony-bundle/advanced-behaviors/client-override-policy) reference: `user_verification` is disabled by default, and the default `allowed_values` is `['required', 'preferred']` (no `discouraged`). Add a security warning explaining the rationale (downgrade attack).
- Cross-link the two pages so users land on the application-level check no matter which side they read first.

## Test plan

- [ ] Render the two pages locally / on the doc preview and verify the GitBook hint blocks display correctly
- [ ] Confirm the cross-links resolve in both directions