### PR TITLE
Document the WebauthnOptionsResponse helpers (#876)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -54,6 +54,7 @@
 * [Credential Record Repository](symfony-bundle/credential-record-repository.md)
 * [User Entity Repository](symfony-bundle/user-entity-repository.md)
 * [Firewall](symfony-bundle/firewall.md)
+* [Options Helpers](symfony-bundle/options-helpers.md)
 * [Configuration References](symfony-bundle/configuration-references.md)
 * [Advanced Behaviors](symfony-bundle/advanced-behaviors/README.md)
   * [Fake Credentials](symfony-bundle/advanced-behaviors/fake-credentials.md)

--- a/symfony-bundle/options-helpers.md
+++ b/symfony-bundle/options-helpers.md
@@ -1,0 +1,192 @@
+# Options Helpers (Custom Controllers)
+
+{% hint style="info" %}
+**New in v5.4.0**
+{% endhint %}
+
+The bundle ships an autowired helper that lets you write your own attestation/assertion *options* controllers without touching a single line of bundle configuration. This is the recommended path going forward: the controllers shipped with the bundle (`AttestationRequestController` / `AssertionRequestController`, driven by `creation_profiles` / `request_profiles`) stay available for backwards compatibility but the helper is more flexible and clearer.
+
+## The entry point
+
+`Webauthn\Bundle\Service\WebauthnOptionsResponse` is autowired and public. It exposes two factory methods, one per ceremony, returning a fluent builder:
+
+```php
+$this->options->forCreation(string $rpId, PublicKeyCredentialUserEntity|UserEntityGuesser $user): WebauthnCreationOptionsBuilder
+$this->options->forRequest(string $rpId, PublicKeyCredentialUserEntity|UserEntityGuesser|null $user = null): WebauthnRequestOptionsBuilder
+```
+
+The required pieces are constructor arguments of the factory call. Everything else has a sensible default and is fluently overridable via `with…()` setters on the returned builder. The terminal call `->build($request)` returns a `JsonResponse` ready to ship.
+
+### User: entity or guesser
+
+The user argument accepts either:
+
+* a `PublicKeyCredentialUserEntity`, when your controller already has it in hand (typical for authenticated flows where you just read `Security::getUser()` and map it to a user entity yourself);
+* a `UserEntityGuesser`, when the user has to be resolved from the request body (typical for the *new user* registration flow where you read `username` / `displayName` from the JSON payload).
+
+For assertion the user is optional: omitting it produces a userless ceremony (passkeys discoverable on the platform side).
+
+### Defaults
+
+The creation builder applies a baseline `pubKeyCredParams` list (in priority order):
+
+* ES256, RS256, EdDSA, ES384, ES512, PS256, RS384, RS512
+
+`challengeLength` defaults to 32 bytes. `timeout`, `userVerification`, `attestation` are left to the W3C-recommended defaults (the user agent decides). On the request side, `allowCredentials` is automatically derived from `CredentialRecordRepositoryInterface::findAllForUserEntity()` when a user is resolved.
+
+## Minimal controllers
+
+### Registration
+
+{% code title="src/Controller/Webauthn/RegisterOptionsController.php" lineNumbers="true" %}
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Webauthn;
+
+use App\Security\NewUserEntityGuesser;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Webauthn\Bundle\Service\WebauthnOptionsResponse;
+
+final class RegisterOptionsController
+{
+    public function __construct(
+        private readonly WebauthnOptionsResponse $options,
+        private readonly NewUserEntityGuesser $guesser,
+    ) {
+    }
+
+    #[Route('/webauthn/register/options', methods: ['POST'])]
+    public function __invoke(Request $request): JsonResponse
+    {
+        return $this->options
+            ->forCreation('example.com', $this->guesser)
+            ->build($request);
+    }
+}
+```
+{% endcode %}
+
+`NewUserEntityGuesser` is a class **you write** that implements `Webauthn\Bundle\Security\Guesser\UserEntityGuesser`. It reads the username from the body, generates a user handle, and returns a `PublicKeyCredentialUserEntity`. The bundle does not ship a generic implementation: that logic is application-specific.
+
+### Authentication, userless (passkeys)
+
+{% code title="src/Controller/Webauthn/LoginOptionsController.php" lineNumbers="true" %}
+```php
+#[Route('/webauthn/login/options', methods: ['POST'])]
+public function __invoke(Request $request): JsonResponse
+{
+    return $this->options
+        ->forRequest('example.com')
+        ->build($request);
+}
+```
+{% endcode %}
+
+No guesser, no allow-list. The user agent will offer the user any platform-side discoverable passkey for `example.com`.
+
+### Authentication, user already known
+
+{% code lineNumbers="true" %}
+```php
+#[Route('/webauthn/step-up/options', methods: ['POST'])]
+public function __invoke(Request $request): JsonResponse
+{
+    $user = $this->mapToWebauthnUserEntity($this->getUser());
+
+    return $this->options
+        ->forRequest('example.com', $user)
+        ->build($request);
+}
+```
+{% endcode %}
+
+`allowCredentials` is automatically derived from your `CredentialRecordRepositoryInterface` for the resolved user.
+
+## Configuring the ceremony
+
+Every optional field has a `with…()` setter on the returned builder. Each call returns a clone, so the entry-point service stays safe to use across requests.
+
+### Common (both creation and request)
+
+| Setter | Default |
+| --- | --- |
+| `withChallengeLength(int)` | 32 |
+| `withTimeout(?int)` | `null` (UA decides) |
+| `withAttestation(?string)` | `null` (= `none`) |
+| `withAttestationFormats(string ...)` | empty (any format accepted) |
+| `withExtensions(AuthenticationExtensions)` | none |
+| `withHints(string ...)` | none |
+| `withClientOverrides(ClientOverridePolicy)` | none (no client field has effect) |
+
+### Creation only
+
+| Setter | Default |
+| --- | --- |
+| `withAuthenticatorSelectionCriteria(AuthenticatorSelectionCriteria)` | none |
+| `withPubKeyCredParams(PublicKeyCredentialParameters ...)` | the W3C-recommended baseline list |
+| `withMediation(?string)` | `null` (= `default`); use `'conditional'` for [Conditional Create](../pure-php/advanced-behaviours/conditional-create.md) |
+| `withHideExistingCredentials(bool = true)` | `false` (excluded credentials are derived from the repository) |
+
+### Request only
+
+| Setter | Default |
+| --- | --- |
+| `withUserVerification(?string)` | `null` (= `preferred` per W3C) |
+| `withUiMode(?string)` | `null` (= `auto`); use `'immediate'` for the L3 immediate flow |
+| `withAllowCredentials(PublicKeyCredentialDescriptor ...)` | derived automatically when a user is resolved |
+| `withDeriveAllowCredentialsFromUser(bool = true)` | `true` |
+
+## Client overrides
+
+By default, **anything in the client request body is ignored**: the server alone decides every field. To let the client influence specific fields, attach a `Webauthn\Bundle\Policy\ClientOverridePolicy`:
+
+{% code lineNumbers="true" %}
+```php
+return $this->options
+    ->forRequest('example.com', $user)
+    ->withUserVerification(AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_PREFERRED)
+    ->withClientOverrides(new ClientOverridePolicy([
+        'user_verification' => [
+            'enabled' => true,
+            'allowed_values' => ['preferred', 'required'],
+        ],
+    ]))
+    ->build($request);
+```
+{% endcode %}
+
+If the client posts `{"userVerification": "required"}`, the merged options carry `required`. If it posts `"discouraged"`, the policy rejects it (not in the allow-list) and the default (`preferred`) wins. Anything outside the policy keys is ignored regardless of what the body contains.
+
+See [Client Override Policy](advanced-behaviors/client-override-policy.md) for the full list of overridable fields.
+
+## Storage
+
+The helper persists the produced options in the bundle's `OptionsStorage` automatically before returning the response. Forgetting to store options is a frequent source of *"challenge mismatch"* errors when the response controller validates the assertion later: the helper removes that risk.
+
+If you want to bypass the helper's storage and call `OptionsStorage` yourself (e.g. to attach extra metadata), you can build the options classes directly using the lib API and skip the helper entirely.
+
+## Why a single entry point?
+
+`WebauthnOptionsResponse` is the only service you inject in your controller. The two builders it returns are typed (`WebauthnCreationOptionsBuilder` and `WebauthnRequestOptionsBuilder`), so the IDE autocomplete only proposes the setters that make sense for the ceremony at hand.
+
+```php
+$this->options->forCreation(...)->withMediation(...);    // ✅ creation has mediation
+$this->options->forRequest(...)->withMediation(...);     // ❌ does not exist on request
+$this->options->forRequest(...)->withUiMode(...);        // ✅ request has uiMode
+$this->options->forCreation(...)->withUiMode(...);       // ❌ does not exist on creation
+```
+
+## Migration from `creation_profiles` / `request_profiles`
+
+If you are still using the bundle's profile-driven controllers, the migration path is straightforward: write a controller of your own that calls the helper, then drop the matching `webauthn.controllers.creation.<name>` / `webauthn.controllers.request.<name>` config block. The route name(s) you previously had can be re-bound to your controller via the `#[Route]` attribute.
+
+## See Also
+
+* [Client Override Policy](advanced-behaviors/client-override-policy.md): what the client can request when a policy is set
+* [Conditional Create](../pure-php/advanced-behaviours/conditional-create.md): the `withMediation('conditional')` flow
+* [Signal API](../pure-php/advanced-behaviours/signal-api.md): same *helpers > config* pattern, applied to the post-ceremony signals


### PR DESCRIPTION
Companion doc PR for [web-auth/webauthn-framework#876](https://github.com/web-auth/webauthn-framework/pull/876).

## What changes

Adds a new top-level page **\`symfony-bundle/options-helpers.md\`** documenting the profile-free helper pattern shipped in 5.4.0. Registered in \`SUMMARY.md\` under *Symfony Bundle*, between *Firewall* and *Configuration References*.

The page covers:

- the single autowired \`WebauthnOptionsResponse\` entry point and its two factory methods (\`forCreation()\` / \`forRequest()\`);
- the entity-or-guesser user argument (either pass a \`PublicKeyCredentialUserEntity\` directly, or hand over a \`UserEntityGuesser\` resolved at \`build()\` time);
- the W3C-recommended \`pubKeyCredParams\` baseline applied by default (ES256 first);
- minimal-controller examples for registration, userless authentication and known-user authentication;
- a setter reference table split between common, creation-only and request-only setters;
- the client-override workflow with a worked example using \`ClientOverridePolicy\`;
- the implicit \`OptionsStorage\` step and why the API is split into two typed builders (IDE autocomplete restricts setters to the matching ceremony);
- a short migration note for users coming from the legacy \`creation_profiles\` / \`request_profiles\` config.

## Linked

- Framework PR: web-auth/webauthn-framework#876
- Memory of #846 design choice: same *helpers > config* pattern.