### PR TITLE
Document per-verifier withAllowedOrigins + withFakeCredentialGenerator

### DIFF
--- a/symfony-bundle/options-helpers.md
+++ b/symfony-bundle/options-helpers.md
@@ -142,6 +142,30 @@ Every optional field has a `with…()` setter on the returned builder. Each call
 | `withUiMode(?string)` | `null` (= `auto`); use `'immediate'` for the L3 immediate flow |
 | `withAllowCredentials(PublicKeyCredentialDescriptor ...)` | derived automatically when a user is resolved |
 | `withDeriveAllowCredentialsFromUser(bool = true)` | `true` |
+| `withFakeCredentialGenerator(?FakeCredentialGenerator)` | the autowired generator (`SimpleFakeCredentialGenerator`); pass `null` to opt out |
+
+#### Username-enumeration protection
+
+When the JSON body carries a `username` (typical login form post: `{"username":"alice"}`) but `alice` does not resolve to a known user, the request builder consults the autowired `FakeCredentialGenerator` and emits **fake** `allowCredentials` instead of an empty list. From the client's standpoint, the response shape is identical whether or not the username matches a real account, so an attacker cannot probe for valid usernames.
+
+Default behaviour (no setup needed):
+
+```php
+return $this->options
+    ->forRequest('example.com')
+    ->build($request);
+```
+
+Opt out (response will be a true userless / empty `allowCredentials` ceremony when the username is unknown):
+
+```php
+return $this->options
+    ->forRequest('example.com')
+    ->withFakeCredentialGenerator(null)
+    ->build($request);
+```
+
+Or swap with a custom implementation of `Webauthn\FakeCredentialGenerator` (e.g. a hash-keyed deterministic generator backed by your `kernel.secret`) by passing it to `withFakeCredentialGenerator($custom)`.
 
 ## Client overrides
 

--- a/symfony-bundle/verification-helpers.md
+++ b/symfony-bundle/verification-helpers.md
@@ -99,7 +99,24 @@ public function __invoke(Request $request): Response
 
 ## Configuring the ceremony
 
-The verifier classes are intentionally lean: most of the configuration that influenced the ceremony has already happened on the *options* side. Only the registration verifier exposes one extra knob.
+Most of the ceremony configuration has already happened on the *options* side; the verifier exposes a small surface to override the bits that matter at validation time.
+
+### Common (both attestation and assertion)
+
+| Setter | Default |
+| --- | --- |
+| `withAllowedOrigins(string ...)` | the global `webauthn.allowed_origins` configuration |
+| `withAllowSubdomains(bool = true)` | the global `webauthn.allow_subdomains` configuration |
+
+Per-verifier override of the accepted origins. When set, the verifier asks the autowired `CeremonyStepManagerFactory` to produce a fresh `CeremonyStepManager` and a fresh validator on top, so the singleton factory's state stays untouched. Use it when one route accepts a different list of origins than the rest of the application (multi-tenant, internal-vs-public, staging vs production, etc.).
+
+```php
+$result = $this->verifier
+    ->forAttestation('example.com')
+    ->withAllowedOrigins('https://app.example.com', 'https://admin.example.com')
+    ->withAllowSubdomains(true)
+    ->verify($request);
+```
 
 ### Attestation only
 


### PR DESCRIPTION
## Summary

Documents web-auth/webauthn-framework#880.

* `verification-helpers.md` gains a new **Common** setter table for `withAllowedOrigins(string ...)` / `withAllowSubdomains(bool)`, with a short explainer about scoped per-verifier overrides and a usage snippet.
* `options-helpers.md` adds `withFakeCredentialGenerator(?FakeCredentialGenerator)` to the request-only setter table, plus a dedicated **Username-enumeration protection** subsection covering the default behaviour, opt-out and custom-generator paths.