### PR TITLE
Update doc snippets to the array form (no variadic)

### DIFF
--- a/migration/from-v5.x-to-v6.0.md
+++ b/migration/from-v5.x-to-v6.0.md
@@ -187,7 +187,7 @@ public function __invoke(Request $request): Response
 {
     $result = $this->verifier
         ->forAttestation('example.com')
-        ->withAllowedOrigins(...$this->origins)
+        ->withAllowedOrigins($this->origins)
         ->withAllowSubdomains(true)
         ->verify($request);
     // ...

--- a/pure-php/advanced-behaviours/signal-api.md
+++ b/pure-php/advanced-behaviours/signal-api.md
@@ -247,13 +247,15 @@ final readonly class WebauthnSignalingSuccessHandler implements SuccessHandler
         ?PublicKeyCredentialUserEntity $userEntity = null,
     ): Response {
         if ($userEntity === null) {
-            return $this->response->withSignals(['status' => 'ok']);
+            return $this->response->withSignals(['status' => 'ok'], []);
         }
 
         return $this->response->withSignals(
             ['status' => 'ok'],
-            $this->signals->forAllAccepted(self::RP_ID, $userEntity),
-            $this->signals->forCurrentUser(self::RP_ID, $userEntity),
+            [
+                $this->signals->forAllAccepted(self::RP_ID, $userEntity),
+                $this->signals->forCurrentUser(self::RP_ID, $userEntity),
+            ],
         );
     }
 }
@@ -316,7 +318,7 @@ final readonly class WebauthnSignalingFailureHandler implements FailureHandler
 
         return $this->response->withSignals(
             ['status' => 'error', 'errorMessage' => $exception?->getMessage() ?? 'Unexpected error'],
-            ...$signals,
+            $signals,
         );
     }
 }
@@ -405,8 +407,10 @@ final class WebauthnAuthenticator extends BaseWebauthnAuthenticator
 
         return $this->response->withSignals(
             ['success' => true],
-            $this->signals->forAllAccepted(self::RP_ID, $user),
-            $this->signals->forCurrentUser(self::RP_ID, $user),
+            [
+                $this->signals->forAllAccepted(self::RP_ID, $user),
+                $this->signals->forCurrentUser(self::RP_ID, $user),
+            ],
         );
     }
 
@@ -422,7 +426,7 @@ final class WebauthnAuthenticator extends BaseWebauthnAuthenticator
 
         return $this->response->withSignals(
             ['success' => false, 'errorMessage' => $exception->getMessage()],
-            ...$signals,
+            $signals,
         );
     }
 

--- a/symfony-bundle/options-helpers.md
+++ b/symfony-bundle/options-helpers.md
@@ -119,9 +119,9 @@ Every optional field has a `with…()` setter on the returned builder. Each call
 | `withChallengeLength(int)` | 32 |
 | `withTimeout(?int)` | `null` (UA decides) |
 | `withAttestation(?string)` | `null` (= `none`) |
-| `withAttestationFormats(string ...)` | empty (any format accepted) |
+| `withAttestationFormats(array)` | empty (any format accepted) |
 | `withExtensions(AuthenticationExtensions)` | none |
-| `withHints(string ...)` | none |
+| `withHints(array)` | none |
 | `withClientOverrides(ClientOverridePolicy)` | none (no client field has effect) |
 | `withOptionsStorage(OptionsStorage)` | the global `webauthn.options_storage` |
 | `withCredentialRepository(CredentialRecordRepositoryInterface)` | the global `webauthn.credential_repository` |
@@ -141,7 +141,7 @@ return $this->options
 | Setter | Default |
 | --- | --- |
 | `withAuthenticatorSelectionCriteria(AuthenticatorSelectionCriteria)` | none |
-| `withPubKeyCredParams(PublicKeyCredentialParameters ...)` | the W3C-recommended baseline list |
+| `withPubKeyCredParams(array)` | the W3C-recommended baseline list |
 | `withMediation(?string)` | `null` (= `default`); use `'conditional'` for [Conditional Create](../pure-php/advanced-behaviours/conditional-create.md) |
 | `withHideExistingCredentials(bool = true)` | `false` (excluded credentials are derived from the repository) |
 
@@ -152,7 +152,7 @@ return $this->options
 | `withUser(PublicKeyCredentialUserEntity\|UserEntityGuesser)` | none (userless ceremony) |
 | `withUserVerification(?string)` | `null` (= `preferred` per W3C) |
 | `withUiMode(?string)` | `null` (= `auto`); use `'immediate'` for the L3 immediate flow |
-| `withAllowCredentials(PublicKeyCredentialDescriptor ...)` | derived automatically when a user is resolved |
+| `withAllowCredentials(array)` | derived automatically when a user is resolved |
 | `withDeriveAllowCredentialsFromUser(bool = true)` | `true` |
 | `withFakeCredentialGenerator(?FakeCredentialGenerator)` | the autowired generator (`SimpleFakeCredentialGenerator`); pass `null` to opt out |
 

--- a/symfony-bundle/verification-helpers.md
+++ b/symfony-bundle/verification-helpers.md
@@ -105,7 +105,7 @@ Most of the ceremony configuration has already happened on the *options* side; t
 
 | Setter | Default |
 | --- | --- |
-| `withAllowedOrigins(string ...)` | the global `webauthn.allowed_origins` configuration |
+| `withAllowedOrigins(array)` | the global `webauthn.allowed_origins` configuration |
 | `withAllowSubdomains(bool = true)` | the global `webauthn.allow_subdomains` configuration |
 | `withTopOriginValidator(?TopOriginValidator)` | the global `webauthn.top_origin_validator` (or none) |
 | `withOptionsStorage(OptionsStorage)` | the global `webauthn.options_storage` |
@@ -116,7 +116,7 @@ Most of the ceremony configuration has already happened on the *options* side; t
 ```php
 $result = $this->verifier
     ->forAttestation('example.com')
-    ->withAllowedOrigins('https://app.example.com', 'https://admin.example.com')
+    ->withAllowedOrigins(['https://app.example.com', 'https://admin.example.com'])
     ->withAllowSubdomains(true)
     ->verify($request);
 ```
@@ -173,7 +173,7 @@ try {
 
     return $this->signalResponse->withSignals(
         ['error' => 'authentication failed'],
-        ...array_filter([$signal])
+        array_values(array_filter([$signal]))
     );
 }
 ```


### PR DESCRIPTION
## Summary

Documents web-auth/webauthn-framework#886 by updating every snippet that called the helper API with the variadic form (`...\$args`) to the new explicit-array form.

* `symfony-bundle/options-helpers.md` — setter table entries for `withAttestationFormats`, `withHints`, `withPubKeyCredParams`, `withAllowCredentials` updated to `(array)`.
* `symfony-bundle/verification-helpers.md` — setter table entry for `withAllowedOrigins` updated to `(array)`; the `withAllowedOrigins('...')` snippet now passes a list literal; the `withSignals(...array_filter(...))` example becomes `withSignals(..., array_values(array_filter(...)))`.
* `migration/from-v5.x-to-v6.0.md` — the multi-origin migration example drops the spread operator (`->withAllowedOrigins(\$this->origins)` instead of `->withAllowedOrigins(...\$this->origins)`).
* `pure-php/advanced-behaviours/signal-api.md` — every `withSignals(\$payload, \$signalA, \$signalB)` call in the SuccessHandler / FailureHandler / Authenticator examples is rewritten as `withSignals(\$payload, [\$signalA, \$signalB])`. The early-return path now passes an empty array (`withSignals(\$payload, [])`).