### PR TITLE
docs(symfony-ux): fix wrong route name and Stimulus action (5.3)

### DIFF
--- a/symfony-ux/additional-authenticators.md
+++ b/symfony-ux/additional-authenticators.md
@@ -117,7 +117,7 @@ Allow authenticated users to register additional authenticators:
         method="post"
         {{ stimulus_controller('@web-auth/webauthn-stimulus',
             {
-                creationOptionsUrl: path('webauthn.controller.creation.creation.add_device'),
+                creationOptionsUrl: path('webauthn.controller.creation.request.add_device'),
                 creationResultField: 'input[name="attestation"]'
             }
         ) }}
@@ -126,7 +126,7 @@ Allow authenticated users to register additional authenticators:
 
         <button
             type="submit"
-            {{ stimulus_action('@web-auth/webauthn-stimulus', 'register') }}
+            {{ stimulus_action('@web-auth/webauthn-stimulus', 'signup') }}
         >
             Register New Authenticator
         </button>

--- a/symfony-ux/installation.md
+++ b/symfony-ux/installation.md
@@ -115,7 +115,7 @@ The first argument is the package-prefixed name — it will resolve to the `--`-
     action="{{ path('app_register') }}"
     method="post"
     {{ stimulus_controller('@web-auth/webauthn-stimulus/registration', {
-        optionsUrl: path('webauthn.controller.creation.creation.new_user'),
+        optionsUrl: path('webauthn.controller.creation.request.new_user'),
         resultUrl: path('app_register'),
         submitViaForm: true
     }) }}

--- a/symfony-ux/user-registration.md
+++ b/symfony-ux/user-registration.md
@@ -20,7 +20,7 @@ Your registration form needs:
     method="post"
     {{ stimulus_controller('@web-auth/webauthn-stimulus',
         {
-            creationOptionsUrl: path('webauthn.controller.creation.creation.new_user'),
+            creationOptionsUrl: path('webauthn.controller.creation.request.new_user'),
             creationResultField: 'input[name="attestation"]'
         }
     ) }}
@@ -46,7 +46,7 @@ Your registration form needs:
 
     <button
         type="submit"
-        {{ stimulus_action('@web-auth/webauthn-stimulus', 'register') }}
+        {{ stimulus_action('@web-auth/webauthn-stimulus', 'signup') }}
     >
         Register with Passkey
     </button>
@@ -127,7 +127,7 @@ Existing users can register additional authenticators (backup keys, different de
     method="post"
     {{ stimulus_controller('@web-auth/webauthn-stimulus',
         {
-            creationOptionsUrl: path('webauthn.controller.creation.creation.add_device'),
+            creationOptionsUrl: path('webauthn.controller.creation.request.add_device'),
             creationResultField: 'input[name="attestation"]'
         }
     ) }}
@@ -136,7 +136,7 @@ Existing users can register additional authenticators (backup keys, different de
 
     <button
         type="submit"
-        {{ stimulus_action('@web-auth/webauthn-stimulus', 'register') }}
+        {{ stimulus_action('@web-auth/webauthn-stimulus', 'signup') }}
     >
         Add New Authenticator
     </button>
@@ -182,7 +182,7 @@ Automatically start the registration process when the page loads:
 {{ stimulus_controller('@web-auth/webauthn-stimulus',
     {
         autoRegister: true,
-        creationOptionsUrl: path('webauthn.controller.creation.creation.new_user'),
+        creationOptionsUrl: path('webauthn.controller.creation.request.new_user'),
         creationResultField: 'input[name="attestation"]'
     }
 ) }}
@@ -209,7 +209,7 @@ The dedicated `registration-controller` provides a focused controller for creden
     action="{{ path('app_register') }}"
     method="post"
     {{ stimulus_controller('@web-auth/webauthn-stimulus/registration', {
-        optionsUrl: path('webauthn.controller.creation.creation.new_user'),
+        optionsUrl: path('webauthn.controller.creation.request.new_user'),
         resultUrl: path('app_register'),
         submitViaForm: true
     }) }}


### PR DESCRIPTION
## Summary

5.3 leg of the 5.2 -> 5.3 -> 5.4 cascade started in #57.

Reported in https://github.com/web-auth/webauthn-framework/issues/893: the registration snippets in `symfony-ux/` referenced a non-existent route and a non-existent Stimulus action, so users following the docs verbatim saw the Register button do nothing.

- `path('webauthn.controller.creation.creation.<X>')` is not a real route. The bundle exposes `webauthn.controller.creation.request.<X>` for the options endpoint (`.response.<X>` for the result endpoint).
- `stimulus_action('@web-auth/webauthn-stimulus', 'register')` targets a method that does not exist on the unified controller. The unified controller exposes `signup` and `signin`. The `register` action only exists on the split `@web-auth/webauthn-stimulus/registration` controller, which is unaffected here.

Files touched:
- `symfony-ux/installation.md` (route fix only on 5.3, the action was already on the split controller)
- `symfony-ux/user-registration.md`
- `symfony-ux/additional-authenticators.md`